### PR TITLE
Fixing note and suggesting cloudflare

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Thai's S3 extension for Magento allows retailers to upload their catalogue and W
 
 **Note:** This extension is only compatible with Magento 1. Please use [Thai's S3 Extension for Magento 2](https://github.com/thaiphan/magento2-s3) for integration with Magento 2.
 
+Digital Ocean
+--------
+Digital Ocean Spaces aims to be compatible with https://developers.digitalocean.com/documentation/spaces/#aws-s3-compatibility
+
 Benefits
 --------
 
@@ -32,9 +36,10 @@ The following assets are automatically saved to S3:
 
 Complex file syncing between multiple servers is now a thing of the past with this extension. All your servers will be able to share the one S3 bucket as the single source of media.
 
-### Easy integration with CloudFront CDN
+### Easy integration with CloudFlare CDN
 
 CloudFront CDN supports using S3 as an origin server so you can significantly reduce load on your servers.
+https://miketabor.com/how-to-host-a-static-website-using-aws-s3-and-Cloudflare/
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ The following assets are automatically saved to S3:
 
 Complex file syncing between multiple servers is now a thing of the past with this extension. All your servers will be able to share the one S3 bucket as the single source of media.
 
-### Easy integration with CloudFlare CDN
+### Easy integration with CloudFlare and CloudFront CDN
 
-CloudFront CDN supports using S3 as an origin server so you can significantly reduce load on your servers.
+CloudFront and Cloudflare CDNs supports using S3 as an origin server so you can significantly reduce load on your servers.
 https://miketabor.com/how-to-host-a-static-website-using-aws-s3-and-Cloudflare/
 
 Installation

--- a/app/code/community/Thai/S3/etc/system.xml
+++ b/app/code/community/Thai/S3/etc/system.xml
@@ -85,7 +85,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <sort_order>70</sort_order>
-                            <comment>Don't include the http:// or https:// prefix.</comment>
+                            <comment>Don't forget to include the http:// or https:// prefix.</comment>
                         </custom_endpoint>
                         <custom_headers>
                             <label>Custom Headers</label>


### PR DESCRIPTION
Description
----
1. The original note on the alternative endpoint read 

> Don't include the http:// or https:// prefix.

However, this is wrong because if you don't include then the module throws the error:
`'Zend_Uri_Exception' with message 'Illegal scheme supplied, only alphanumeric characters are permitted'`

Include `https://` and the error goes away and the export succeeds.

2. Also I edited the readme to suggest DigitalOcean and Cloudflare as usecases.